### PR TITLE
feat(runtime): add variable store, event dispatcher, and profile state

### DIFF
--- a/sentinel/runtime/event_dispatcher.lua
+++ b/sentinel/runtime/event_dispatcher.lua
@@ -1,0 +1,258 @@
+-- sentinel/runtime/event_dispatcher.lua
+-- Maps Sylvannas game events to runtime events.
+-- Listens on the Sylvannas core.event_bus and re-dispatches as runtime events
+-- on the internal event_bus with structured payloads.
+
+local EventDispatcher = {}
+EventDispatcher.__index = EventDispatcher
+
+---Create a new EventDispatcher
+---@param event_bus table The SentinelCore internal event bus
+---@param blackboard table The SentinelCore blackboard
+---@return table EventDispatcher instance
+function EventDispatcher:new(event_bus, blackboard)
+    local o = setmetatable({}, EventDispatcher)
+    o._event_bus = event_bus
+    o._blackboard = blackboard
+    o._sylvannas_tokens = {}  -- tokens from Sylvannas core.event_bus subscriptions
+    o._runtime_subs = {}      -- { token = handler } for runtime event subscriptions
+    o._next_token = 0
+    o._started = false
+    return o
+end
+
+---Start the dispatcher: subscribe to Sylvannas events
+---Uses pcall to gracefully skip missing Sylvannas events
+function EventDispatcher:start()
+    if self._started then
+        return
+    end
+
+    local core_eb = _G.core and _G.core.event_bus
+    if not core_eb then
+        -- No Sylvannas event bus available; silently skip
+        self._started = true
+        return
+    end
+
+    local tokens = {}
+
+    -- QUEST_LOG_UPDATE → "quest_accepted" / "quest_completed" / "quest_failed"
+    local ok, token = pcall(core_eb.on, core_eb, "QUEST_LOG_UPDATE", function()
+        self:_handle_quest_log_update()
+    end)
+    if ok then
+        table.insert(tokens, token)
+    end
+
+    -- UNIT_HEALTH → "health_changed"
+    ok, token = pcall(core_eb.on, core_eb, "UNIT_HEALTH", function(guid, health, max_health)
+        self:_handle_unit_health(guid, health, max_health)
+    end)
+    if ok then
+        table.insert(tokens, token)
+    end
+
+    -- BAG_UPDATE → "inventory_changed"
+    ok, token = pcall(core_eb.on, core_eb, "BAG_UPDATE", function(bag_id)
+        self:_handle_bag_update(bag_id)
+    end)
+    if ok then
+        table.insert(tokens, token)
+    end
+
+    -- PLAYER_ENTERING_WORLD → "zone_entered"
+    ok, token = pcall(core_eb.on, core_eb, "PLAYER_ENTERING_WORLD", function()
+        self:_handle_player_entering_world()
+    end)
+    if ok then
+        table.insert(tokens, token)
+    end
+
+    -- PLAYER_DEATH → "death_event"
+    ok, token = pcall(core_eb.on, core_eb, "PLAYER_DEATH", function()
+        self:_handle_player_death()
+    end)
+    if ok then
+        table.insert(tokens, token)
+    end
+
+    -- UNIT_COMBAT → "kill_event"
+    ok, token = pcall(core_eb.on, core_eb, "UNIT_COMBAT", function(creature_entry, x, y, z)
+        self:_handle_unit_combat(creature_entry, x, y, z)
+    end)
+    if ok then
+        table.insert(tokens, token)
+    end
+
+    self._sylvannas_tokens = tokens
+    self._started = true
+end
+
+---Stop the dispatcher: unsubscribe all Sylvannas events
+function EventDispatcher:stop()
+    if not self._started then
+        return
+    end
+
+    local core_eb = _G.core and _G.core.event_bus
+    if core_eb then
+        for _, token in ipairs(self._sylvannas_tokens) do
+            pcall(core_eb.off, core_eb, token)
+        end
+    end
+
+    self._sylvannas_tokens = {}
+    self._started = false
+end
+
+---Subscribe to a runtime event
+---@param event_name string The runtime event name
+---@param handler function Payload receiver
+---@return string token Subscription token for removal
+function EventDispatcher:on_runtime_event(event_name, handler)
+    self._next_token = self._next_token + 1
+    local token = "runtime_sub:" .. tostring(self._next_token)
+
+    if not self._runtime_subs[event_name] then
+        self._runtime_subs[event_name] = {}
+    end
+
+    table.insert(self._runtime_subs[event_name], {
+        token = token,
+        handler = handler,
+    })
+
+    return token
+end
+
+---Remove a runtime event subscription by token
+---@param token string The token returned from on_runtime_event
+---@return boolean success
+function EventDispatcher:off_runtime_event(token)
+    for event_name, subs in pairs(self._runtime_subs) do
+        for i = #subs, 1, -1 do
+            if subs[i].token == token then
+                table.remove(subs, i)
+                if #subs == 0 then
+                    self._runtime_subs[event_name] = nil
+                end
+                return true
+            end
+        end
+    end
+    return false
+end
+
+---Publish a runtime event to subscribers
+---@param event_name string
+---@param payload table
+function EventDispatcher:_publish_runtime(event_name, payload)
+    local subs = self._runtime_subs[event_name]
+    if not subs then
+        return
+    end
+
+    -- Snapshot to avoid mutation during iteration
+    local snapshot = {}
+    for i, sub in ipairs(subs) do
+        snapshot[i] = sub
+    end
+
+    for _, sub in ipairs(snapshot) do
+        local ok, err = pcall(sub.handler, payload)
+        if not ok and self._event_bus then
+            self._event_bus:publish("system:error", {
+                module = "event_dispatcher",
+                operation = event_name,
+                error = tostring(err),
+            })
+        end
+    end
+end
+
+---Handle QUEST_LOG_UPDATE: determine what changed
+function EventDispatcher:_handle_quest_log_update()
+    -- Sylvannas doesn't always tell us WHAT changed,
+    -- so we publish all three events and let logic sort it out
+    -- with a best-guess: publish "quest_accepted" as the primary signal.
+    -- In practice, the subscriber checks quest log state.
+    self:_publish_runtime("quest_accepted", { quest_id = nil })
+    self:_publish_runtime("quest_completed", { quest_id = nil })
+    self:_publish_runtime("quest_failed", { quest_id = nil })
+end
+
+---Handle UNIT_HEALTH
+---@param guid string|nil Unit GUID
+---@param health number|nil Current health
+---@param max_health number|nil Maximum health
+function EventDispatcher:_handle_unit_health(guid, health, max_health)
+    self:_publish_runtime("health_changed", {
+        guid = guid,
+        health = health,
+        max_health = max_health,
+    })
+end
+
+---Handle BAG_UPDATE
+---@param bag_id number|nil Bag slot ID
+function EventDispatcher:_handle_bag_update(bag_id)
+    self:_publish_runtime("inventory_changed", {
+        bag_id = bag_id,
+    })
+end
+
+---Handle PLAYER_ENTERING_WORLD
+function EventDispatcher:_handle_player_entering_world()
+    local zone_name = nil
+    local map_id = nil
+
+    if _G.core and _G.core.player then
+        -- Try to get zone info from player state
+        local ok, zone = pcall(_G.core.player.get_zone_name)
+        if ok then
+            zone_name = zone
+        end
+        ok, map_id = pcall(_G.core.player.get_map_id)
+        if not ok then
+            map_id = nil
+        end
+    end
+
+    self:_publish_runtime("zone_entered", {
+        zone_name = zone_name,
+        map_id = map_id,
+    })
+end
+
+---Handle PLAYER_DEATH
+function EventDispatcher:_handle_player_death()
+    local position = nil
+    local killer_guid = nil
+
+    if _G.core and _G.core.player then
+        local ok, pos = pcall(_G.core.player.get_position)
+        if ok then
+            position = pos
+        end
+    end
+
+    self:_publish_runtime("death_event", {
+        position = position,
+        killer_guid = killer_guid,
+    })
+end
+
+---Handle UNIT_COMBAT
+---@param creature_entry number|nil Creature template entry ID
+---@param x number|nil Position X
+---@param y number|nil Position Y
+---@param z number|nil Position Z
+function EventDispatcher:_handle_unit_combat(creature_entry, x, y, z)
+    self:_publish_runtime("kill_event", {
+        creature_entry = creature_entry,
+        position = { x = x, y = y, z = z },
+    })
+end
+
+return EventDispatcher

--- a/sentinel/runtime/profile_state.lua
+++ b/sentinel/runtime/profile_state.lua
@@ -1,0 +1,215 @@
+-- sentinel/runtime/profile_state.lua
+-- Profile and Operation state machine.
+-- Profile states: idle → ready → executing → waiting → finished (back to idle)
+-- Operation states: locked → ready → active → completed|failed|aborted|skipped
+
+local ProfileState = {}
+ProfileState.__index = ProfileState
+
+-- Valid profile state transitions
+local PROFILE_TRANSITIONS = {
+    idle = { ready = true },
+    ready = { executing = true },
+    executing = { waiting = true, idle = true },
+    waiting = { executing = true, idle = true },
+    finished = { idle = true },
+}
+
+local PROFILE_STATES = {
+    idle = true,
+    ready = true,
+    executing = true,
+    waiting = true,
+    finished = true,
+}
+
+-- Valid operation state transitions
+local OP_TRANSITIONS = {
+    locked = { ready = true },
+    ready = { active = true },
+    active = { completed = true, failed = true, aborted = true, skipped = true },
+}
+
+local OP_STATES = {
+    locked = true,
+    ready = true,
+    active = true,
+    completed = true,
+    failed = true,
+    aborted = true,
+    skipped = true,
+}
+
+---Create a new ProfileState
+---@param blackboard table The SentinelCore blackboard
+---@param event_bus table The SentinelCore event bus
+---@return table ProfileState instance
+function ProfileState:new(blackboard, event_bus)
+    local o = setmetatable({}, ProfileState)
+    o._blackboard = blackboard
+    o._event_bus = event_bus
+    return o
+end
+
+---Validate and set the profile state
+---@param state string Target state
+---@return boolean true if transition was valid and applied, false otherwise
+function ProfileState:set_profile_state(state)
+    if not PROFILE_STATES[state] then
+        return false
+    end
+
+    local current = self:get_profile_state()
+    if not current then
+        -- No current state; set it directly
+        self._blackboard:set("module.runtime.profile_state", state)
+        if self._event_bus then
+            self._event_bus:publish("profile_state_changed", {
+                from = nil,
+                to = state,
+            })
+        end
+        return true
+    end
+
+    -- Allow re-setting to the same state
+    if current == state then
+        return true
+    end
+
+    -- Check if the transition is valid
+    local allowed = PROFILE_TRANSITIONS[current]
+    if not allowed or not allowed[state] then
+        return false
+    end
+
+    -- Apply the transition
+    self._blackboard:set("module.runtime.profile_state", state)
+    if self._event_bus then
+        self._event_bus:publish("profile_state_changed", {
+            from = current,
+            to = state,
+        })
+    end
+    return true
+end
+
+---Get the current profile state
+---@return string|nil
+function ProfileState:get_profile_state()
+    return self._blackboard:get("module.runtime.profile_state")
+end
+
+---Validate and set an operation's state
+---@param op_id string Operation ID
+---@param state string Target state
+---@return boolean true if transition was valid and applied, false otherwise
+function ProfileState:set_operation_state(op_id, state)
+    if type(op_id) ~= "string" or op_id == "" then
+        return false
+    end
+    if not OP_STATES[state] then
+        return false
+    end
+
+    local current = self:get_operation_state(op_id)
+
+    if not current then
+        -- No current state; set it directly (must start as "locked")
+        if state ~= "locked" then
+            return false
+        end
+        self:_set_op_state_internal(op_id, state, nil)
+        return true
+    end
+
+    -- Allow re-setting to the same state (idempotent)
+    if current == state then
+        return true
+    end
+
+    -- Check if the transition is valid
+    local allowed = OP_TRANSITIONS[current]
+    if not allowed or not allowed[state] then
+        return false
+    end
+
+    self:_set_op_state_internal(op_id, state, current)
+    return true
+end
+
+---Internal helper to set op state in blackboard and publish event
+---@param op_id string
+---@param state string
+---@param previous string|nil
+function ProfileState:_set_op_state_internal(op_id, state, previous)
+    local key = "module.runtime.operations." .. tostring(op_id) .. ".state"
+    self._blackboard:set(key, state)
+    if self._event_bus then
+        self._event_bus:publish("operation_state_changed", {
+            operation_id = op_id,
+            from = previous,
+            to = state,
+        })
+    end
+end
+
+---Get the current state of an operation
+---@param op_id string Operation ID
+---@return string|nil
+function ProfileState:get_operation_state(op_id)
+    if type(op_id) ~= "string" or op_id == "" then
+        return nil
+    end
+    local key = "module.runtime.operations." .. tostring(op_id) .. ".state"
+    return self._blackboard:get(key)
+end
+
+---Set recovery action for an operation
+---@param op_id string Operation ID
+---@param action string "retry"|"skip"|"abort"
+---@return boolean
+function ProfileState:set_recovery(op_id, action)
+    if type(op_id) ~= "string" or op_id == "" then
+        return false
+    end
+    if action ~= "retry" and action ~= "skip" and action ~= "abort" then
+        return false
+    end
+    local key = "module.runtime.operations." .. tostring(op_id) .. ".recovery"
+    self._blackboard:set(key, action)
+    return true
+end
+
+---Get recovery action for an operation
+---@param op_id string Operation ID
+---@return string|nil
+function ProfileState:get_recovery(op_id)
+    if type(op_id) ~= "string" or op_id == "" then
+        return nil
+    end
+    local key = "module.runtime.operations." .. tostring(op_id) .. ".recovery"
+    return self._blackboard:get(key)
+end
+
+---Reset all state: clear profile state and all operation states
+function ProfileState:reset()
+    -- Clear profile state
+    self._blackboard:clear("module.runtime.profile_state")
+
+    -- Clear all operation states
+    local prefix = "module.runtime.operations."
+    local snapshot = self._blackboard:snapshot(prefix)
+    for key, _ in pairs(snapshot) do
+        self._blackboard:clear(key)
+    end
+
+    if self._event_bus then
+        self._event_bus:publish("profile_state_changed", {
+            from = nil,
+            to = nil,
+        })
+    end
+end
+
+return ProfileState

--- a/sentinel/runtime/variable_store.lua
+++ b/sentinel/runtime/variable_store.lua
@@ -1,0 +1,198 @@
+-- sentinel/runtime/variable_store.lua
+-- Typed key-value store for profile state.
+-- Variables are stored in the blackboard at module.runtime.variables.{scope}.{key}
+
+local VariableStore = {}
+VariableStore.__index = VariableStore
+
+local VALID_TYPES = {
+    bool = true,
+    integer = true,
+    float = true,
+    string = true,
+    position = true,
+}
+
+---Determine the Sylvannas type of a Lua value
+---@param value any
+---@return string|nil type_name "bool"|"integer"|"float"|"string"|"position"|nil
+---@return string|nil error
+local function infer_type(value)
+    local t = type(value)
+    if t == "boolean" then
+        return "bool", nil
+    elseif t == "number" then
+        if math.floor(value) == value then
+            return "integer", nil
+        else
+            return "float", nil
+        end
+    elseif t == "string" then
+        return "string", nil
+    elseif t == "table" then
+        if value.x ~= nil and value.y ~= nil and value.zone ~= nil then
+            return "position", nil
+        end
+        return nil, "invalid_type: table must have x, y, and zone fields for position"
+    end
+    return nil, "invalid_type: unsupported Lua type " .. tostring(t)
+end
+
+---Create a new VariableStore
+---@param blackboard table The SentinelCore blackboard
+---@return table VariableStore instance
+function VariableStore:new(blackboard)
+    local o = setmetatable({}, VariableStore)
+    o._blackboard = blackboard
+    return o
+end
+
+---Build the blackboard key for a given scope and variable name
+---@param scope string "global" or operation_id
+---@param key string Variable name
+---@return string Full blackboard key
+function VariableStore:_build_key(scope, key)
+    return "module.runtime.variables." .. tostring(scope) .. "." .. tostring(key)
+end
+
+---Type-checked write.
+---scope is "global" or an operation_id string
+---@param scope string
+---@param key string
+---@param value any
+---@return boolean success
+---@return string|nil error
+function VariableStore:set(scope, key, value)
+    if type(scope) ~= "string" or scope == "" then
+        return false, "scope must be a non-empty string"
+    end
+    if type(key) ~= "string" or key == "" then
+        return false, "key must be a non-empty string"
+    end
+
+    local type_name, err = infer_type(value)
+    if not type_name then
+        return false, err
+    end
+
+    local bb_key = self:_build_key(scope, key)
+    self._blackboard:set(bb_key, value)
+    return true, nil
+end
+
+---Read with global fallthrough (if not in operation scope, checks global)
+---@param scope string
+---@param key string
+---@return any|nil value
+function VariableStore:get(scope, key)
+    if type(scope) ~= "string" or scope == "" then
+        return nil
+    end
+    if type(key) ~= "string" or key == "" then
+        return nil
+    end
+
+    local bb_key = self:_build_key(scope, key)
+    local value = self._blackboard:get(bb_key)
+    if value ~= nil then
+        return value
+    end
+
+    -- Global fallthrough: if scope is not "global", check the global scope
+    if scope ~= "global" then
+        local global_key = self:_build_key("global", key)
+        return self._blackboard:get(global_key)
+    end
+
+    return nil
+end
+
+---Check existence of a variable
+---@param scope string
+---@param key string
+---@return boolean
+function VariableStore:has(scope, key)
+    if type(scope) ~= "string" or scope == "" then
+        return false
+    end
+    if type(key) ~= "string" or key == "" then
+        return false
+    end
+
+    local bb_key = self:_build_key(scope, key)
+    return self._blackboard:has(bb_key)
+end
+
+---Remove a variable
+---@param scope string
+---@param key string
+---@return boolean success (true if the key existed)
+function VariableStore:delete(scope, key)
+    if type(scope) ~= "string" or scope == "" then
+        return false
+    end
+    if type(key) ~= "string" or key == "" then
+        return false
+    end
+
+    local bb_key = self:_build_key(scope, key)
+    if not self._blackboard:has(bb_key) then
+        return false
+    end
+    self._blackboard:clear(bb_key)
+    return true
+end
+
+---Return the list of variable keys in a scope
+---Returns only the keys within module.runtime.variables.{scope}.
+---@param scope string
+---@return table List of variable names (strings)
+function VariableStore:list(scope)
+    if type(scope) ~= "string" or scope == "" then
+        return {}
+    end
+
+    local prefix = "module.runtime.variables." .. tostring(scope) .. "."
+    local snapshot = self._blackboard:snapshot(prefix)
+    local keys = {}
+    for full_key, _ in pairs(snapshot) do
+        -- Extract the variable name (everything after the scope prefix)
+        local var_name = full_key:sub(#prefix + 1)
+        if var_name and var_name ~= "" then
+            table.insert(keys, var_name)
+        end
+    end
+    table.sort(keys)
+    return keys
+end
+
+---Clear all variables in a scope
+---@param scope string
+---@return boolean success
+function VariableStore:clear_scope(scope)
+    if type(scope) ~= "string" or scope == "" then
+        return false
+    end
+
+    local prefix = "module.runtime.variables." .. tostring(scope) .. "."
+    local snapshot = self._blackboard:snapshot(prefix)
+    for full_key, _ in pairs(snapshot) do
+        self._blackboard:clear(full_key)
+    end
+    return true
+end
+
+---Get the Sylvannas type of a variable
+---@param scope string
+---@param key string
+---@return string|nil type_name "bool"|"integer"|"float"|"string"|"position"|nil
+function VariableStore:get_type(scope, key)
+    local value = self:get(scope, key)
+    if value == nil then
+        return nil
+    end
+    local type_name, _ = infer_type(value)
+    return type_name
+end
+
+return VariableStore

--- a/sentinel/tests/run_offline.lua
+++ b/sentinel/tests/run_offline.lua
@@ -160,6 +160,9 @@ local test_modules = {
     "tests/runtime/test_operation_scheduler",
     "tests/runtime/test_action_executor",
     "tests/runtime/test_runtime_engine",
+    "tests/runtime/test_variable_store",
+    "tests/runtime/test_event_dispatcher",
+    "tests/runtime/test_profile_state",
 
     -- Combat module
     "tests/modules/combat/test_spell_catalog",

--- a/sentinel/tests/runtime/test_event_dispatcher.lua
+++ b/sentinel/tests/runtime/test_event_dispatcher.lua
@@ -1,0 +1,273 @@
+-- sentinel/tests/runtime/test_event_dispatcher.lua
+-- Tests for runtime/event_dispatcher.lua
+
+local Blackboard = require("core/blackboard")
+local EventBus = require("core/event_bus")
+local T = require("tests/test_util")
+local Mock = require("tests/harness/mocks/sylvannas_api")
+
+local M = {}
+
+function M.run()
+    print("=== Event Dispatcher Tests ===")
+
+    -- Set up mock Sylvannas core
+    Mock.setup_globals()
+
+    -- =====================================================================
+    -- Test 1: Construction
+    -- =====================================================================
+    print("Test 1: Construction")
+    local bb = Blackboard:new()
+    local eb = EventBus:new()
+    local EventDispatcher = require("runtime/event_dispatcher")
+    local ed = EventDispatcher:new(eb, bb)
+    T.assert_not_nil(ed, "EventDispatcher instance should not be nil")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 2: Start and stop dispatcher gracefully
+    -- =====================================================================
+    print("Test 2: Start and stop dispatcher")
+    local bb2 = Blackboard:new()
+    local eb2 = EventBus:new()
+    local ed2 = EventDispatcher:new(eb2, bb2)
+    -- Should not error when Sylvannas event bus doesn't have the events
+    ed2:start()
+    T.assert_true(true, "start should not error")
+    ed2:stop()
+    T.assert_true(true, "stop should not error")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 3: Start is idempotent
+    -- =====================================================================
+    print("Test 3: Start is idempotent")
+    local bb3 = Blackboard:new()
+    local eb3 = EventBus:new()
+    local ed3 = EventDispatcher:new(eb3, bb3)
+    ed3:start()
+    ed3:start()  -- Second start should be no-op
+    ed3:stop()
+    T.assert_true(true, "double start should not error")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 4: Stop is idempotent
+    -- =====================================================================
+    print("Test 4: Stop is idempotent")
+    local bb4 = Blackboard:new()
+    local eb4 = EventBus:new()
+    local ed4 = EventDispatcher:new(eb4, bb4)
+    ed4:stop()  -- Stop without start
+    ed4:stop()  -- Double stop
+    T.assert_true(true, "double stop should not error")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 5: Subscribe to runtime events and receive notifications
+    -- =====================================================================
+    print("Test 5: Subscribe to runtime events")
+    local bb5 = Blackboard:new()
+    local eb5 = EventBus:new()
+    local ed5 = EventDispatcher:new(eb5, bb5)
+    ed5:start()
+
+    local received = {}
+    local token = ed5:on_runtime_event("kill_event", function(payload)
+        table.insert(received, payload)
+    end)
+    T.assert_not_nil(token, "subscription token should not be nil")
+    T.assert_true(type(token) == "string", "token should be a string")
+
+    -- Manually trigger the handler
+    ed5:_handle_unit_combat(12345, 100, 200, 30)
+    T.assert_equal(#received, 1, "should have received 1 kill_event")
+    T.assert_equal(received[1].creature_entry, 12345, "creature entry should match")
+    T.assert_equal(received[1].position.x, 100, "x should match")
+    T.assert_equal(received[1].position.y, 200, "y should match")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 6: Unsubscribe from runtime events
+    -- =====================================================================
+    print("Test 6: Unsubscribe from runtime events")
+    local bb6 = Blackboard:new()
+    local eb6 = EventBus:new()
+    local ed6 = EventDispatcher:new(eb6, bb6)
+    ed6:start()
+
+    local count = 0
+    local token6 = ed6:on_runtime_event("health_changed", function()
+        count = count + 1
+    end)
+
+    -- Fire event
+    ed6:_handle_unit_health("Player-1", 50, 100)
+    T.assert_equal(count, 1, "handler should have been called once")
+
+    -- Unsubscribe
+    local removed = ed6:off_runtime_event(token6)
+    T.assert_true(removed, "off_runtime_event should return true")
+
+    -- Fire again - handler should not be called
+    ed6:_handle_unit_health("Player-1", 25, 100)
+    T.assert_equal(count, 1, "handler should not have been called after unsubscribe")
+
+    -- Remove again should return false
+    local removed2 = ed6:off_runtime_event(token6)
+    T.assert_false(removed2, "second removal should return false")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 7: Event dispatch with proper payloads
+    -- =====================================================================
+    print("Test 7: Event dispatch payloads")
+    local bb7 = Blackboard:new()
+    local eb7 = EventBus:new()
+    local ed7 = EventDispatcher:new(eb7, bb7)
+    ed7:start()
+
+    local events = {}
+    ed7:on_runtime_event("health_changed", function(p) table.insert(events, { name = "health_changed", p = p }) end)
+    ed7:on_runtime_event("inventory_changed", function(p) table.insert(events, { name = "inventory_changed", p = p }) end)
+    ed7:on_runtime_event("zone_entered", function(p) table.insert(events, { name = "zone_entered", p = p }) end)
+    ed7:on_runtime_event("death_event", function(p) table.insert(events, { name = "death_event", p = p }) end)
+    ed7:on_runtime_event("kill_event", function(p) table.insert(events, { name = "kill_event", p = p }) end)
+
+    -- Trigger handlers manually
+    ed7:_handle_unit_health("Player-1", 75, 100)
+    ed7:_handle_bag_update(5)
+    ed7:_handle_player_entering_world()
+    ed7:_handle_player_death()
+    ed7:_handle_unit_combat(67890, 10, 20, 30)
+
+    T.assert_equal(#events, 5, "should have received 5 events")
+
+    -- Check health_changed payload
+    local hc = events[1]
+    T.assert_equal(hc.name, "health_changed")
+    T.assert_equal(hc.p.guid, "Player-1")
+    T.assert_equal(hc.p.health, 75)
+    T.assert_equal(hc.p.max_health, 100)
+
+    -- Check inventory_changed payload
+    local inv = events[2]
+    T.assert_equal(inv.name, "inventory_changed")
+    T.assert_equal(inv.p.bag_id, 5)
+
+    -- Check zone_entered payload
+    local zone = events[3]
+    T.assert_equal(zone.name, "zone_entered")
+    -- zone may have nil fields since mock doesn't have get_zone_name
+
+    -- Check death_event payload
+    local death = events[4]
+    T.assert_equal(death.name, "death_event")
+    -- position may be nil or have mock data
+
+    -- Check kill_event payload
+    local kill = events[5]
+    T.assert_equal(kill.name, "kill_event")
+    T.assert_equal(kill.p.creature_entry, 67890)
+    T.assert_equal(kill.p.position.x, 10)
+    T.assert_equal(kill.p.position.y, 20)
+
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 8: Multiple subscribers to same event
+    -- =====================================================================
+    print("Test 8: Multiple subscribers to same event")
+    local bb8 = Blackboard:new()
+    local eb8 = EventBus:new()
+    local ed8 = EventDispatcher:new(eb8, bb8)
+    ed8:start()
+
+    local call_a = 0
+    local call_b = 0
+    ed8:on_runtime_event("health_changed", function() call_a = call_a + 1 end)
+    ed8:on_runtime_event("health_changed", function() call_b = call_b + 1 end)
+
+    ed8:_handle_unit_health("Test", 100, 100)
+    T.assert_equal(call_a, 1, "handler a should be called")
+    T.assert_equal(call_b, 1, "handler b should be called")
+
+    -- Fire again
+    ed8:_handle_unit_health("Test", 50, 100)
+    T.assert_equal(call_a, 2, "handler a should be called twice")
+    T.assert_equal(call_b, 2, "handler b should be called twice")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 9: Subscription token uniqueness
+    -- =====================================================================
+    print("Test 9: Subscription token uniqueness")
+    local bb9 = Blackboard:new()
+    local eb9 = EventBus:new()
+    local ed9 = EventDispatcher:new(eb9, bb9)
+    ed9:start()
+
+    local t1 = ed9:on_runtime_event("quest_accepted", function() end)
+    local t2 = ed9:on_runtime_event("quest_completed", function() end)
+    local t3 = ed9:on_runtime_event("quest_accepted", function() end)
+
+    T.assert_false(t1 == t2, "tokens should be different (t1 vs t2)")
+    T.assert_false(t1 == t3, "tokens should be different (t1 vs t3)")
+    T.assert_false(t2 == t3, "tokens should be different (t2 vs t3)")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 10: Handle Sylvannas event dispatch via core.event_bus
+    -- =====================================================================
+    print("Test 10: Core event bus integration")
+    local bb10 = Blackboard:new()
+    local eb10 = EventBus:new()
+    local ed10 = EventDispatcher:new(eb10, bb10)
+
+    -- Set up core.event_bus with Sylvannas-style API
+    local sylvannas_eb = {
+        _subs = {},
+        on = function(self, event, handler)
+            if not self._subs[event] then
+                self._subs[event] = {}
+            end
+            table.insert(self._subs[event], handler)
+            return event .. "_token"
+        end,
+        off = function(self, token)
+            return true
+        end,
+    }
+    _G.core.event_bus = sylvannas_eb
+
+    local captured = {}
+    ed10:on_runtime_event("quest_accepted", function(p) table.insert(captured, p) end)
+
+    ed10:start()
+
+    -- Verify subscription tokens were stored
+    T.assert_equal(#ed10._sylvannas_tokens, 6, "should have 6 Sylvannas subscription tokens")
+
+    -- Simulate a Sylvannas event being triggered
+    -- FIX: Our ed10 subscribed via pcall(core_eb.on, core_eb, "QUEST_LOG_UPDATE", handler)
+    -- So we need to trigger the handler that was passed to sylvannas_eb.on
+    local quest_handlers = sylvannas_eb._subs["QUEST_LOG_UPDATE"]
+    T.assert_not_nil(quest_handlers, "QUEST_LOG_UPDATE should have a handler")
+    T.assert_equal(#quest_handlers, 1, "should have 1 QUEST_LOG_UPDATE handler")
+
+    -- Trigger the handler
+    quest_handlers[1]()
+    T.assert_equal(#captured, 1, "should have captured 1 quest_accepted event")
+
+    ed10:stop()
+    T.assert_equal(#ed10._sylvannas_tokens, 0, "tokens should be cleared after stop")
+    print("  PASS")
+
+    -- Clean up
+    Mock.reset()
+
+    print("\n=== All EventDispatcher Tests PASSED ===")
+end
+
+return M

--- a/sentinel/tests/runtime/test_profile_state.lua
+++ b/sentinel/tests/runtime/test_profile_state.lua
@@ -1,0 +1,363 @@
+-- sentinel/tests/runtime/test_profile_state.lua
+-- Tests for runtime/profile_state.lua
+
+local Blackboard = require("core/blackboard")
+local EventBus = require("core/event_bus")
+local T = require("tests/test_util")
+
+local M = {}
+
+function M.run()
+    print("=== Profile State Tests ===")
+
+    -- =====================================================================
+    -- Test 1: Construction
+    -- =====================================================================
+    print("Test 1: Construction")
+    local bb = Blackboard:new()
+    local eb = EventBus:new()
+    local ProfileState = require("runtime/profile_state")
+    local ps = ProfileState:new(bb, eb)
+    T.assert_not_nil(ps, "ProfileState instance should not be nil")
+    T.assert_nil(ps:get_profile_state(), "initial profile state should be nil")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 2: Set initial profile state
+    -- =====================================================================
+    print("Test 2: Set initial profile state")
+    local bb2 = Blackboard:new()
+    local eb2 = EventBus:new()
+    local ps2 = ProfileState:new(bb2, eb2)
+
+    local ok = ps2:set_profile_state("idle")
+    T.assert_true(ok, "setting initial state 'idle' should succeed")
+    T.assert_equal(ps2:get_profile_state(), "idle", "profile state should be 'idle'")
+    T.assert_equal(bb2:get("module.runtime.profile_state"), "idle", "blackboard should reflect 'idle'")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 3: Valid transition: idle → ready
+    -- =====================================================================
+    print("Test 3: Valid transition idle → ready")
+    local bb3 = Blackboard:new()
+    local eb3 = EventBus:new()
+    local ps3 = ProfileState:new(bb3, eb3)
+    ps3:set_profile_state("idle")
+    local ok = ps3:set_profile_state("ready")
+    T.assert_true(ok, "idle → ready should succeed")
+    T.assert_equal(ps3:get_profile_state(), "ready", "state should be 'ready'")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 4: Full profile state cycle
+    -- =====================================================================
+    print("Test 4: Full profile state cycle")
+    local bb4 = Blackboard:new()
+    local eb4 = EventBus:new()
+    local ps4 = ProfileState:new(bb4, eb4)
+
+    T.assert_true(ps4:set_profile_state("idle"), "→ idle")
+    T.assert_true(ps4:set_profile_state("ready"), "→ ready")
+    T.assert_true(ps4:set_profile_state("executing"), "→ executing")
+    T.assert_true(ps4:set_profile_state("waiting"), "→ waiting")
+    T.assert_true(ps4:set_profile_state("executing"), "→ executing (back)")
+    T.assert_true(ps4:set_profile_state("idle"), "→ idle (from executing)")
+    T.assert_true(ps4:set_profile_state("ready"), "→ ready")
+    T.assert_true(ps4:set_profile_state("executing"), "→ executing")
+    T.assert_true(ps4:set_profile_state("idle"), "→ idle")
+    T.assert_true(ps4:set_profile_state("ready"), "→ ready")
+    T.assert_true(ps4:set_profile_state("executing"), "→ executing")
+    T.assert_true(ps4:set_profile_state("waiting"), "→ waiting")
+    T.assert_true(ps4:set_profile_state("idle"), "→ idle (from waiting)")
+    T.assert_equal(ps4:get_profile_state(), "idle", "final state should be 'idle'")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 5: Invalid profile state transition
+    -- =====================================================================
+    print("Test 5: Invalid profile state transition")
+    local bb5 = Blackboard:new()
+    local eb5 = EventBus:new()
+    local ps5 = ProfileState:new(bb5, eb5)
+    ps5:set_profile_state("idle")
+
+    -- Can't jump from idle to executing (must go through ready first)
+    local ok = ps5:set_profile_state("executing")
+    T.assert_false(ok, "idle → executing should be invalid")
+    T.assert_equal(ps5:get_profile_state(), "idle", "state should remain 'idle'")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 6: Invalid profile state name
+    -- =====================================================================
+    print("Test 6: Invalid profile state name")
+    local bb6 = Blackboard:new()
+    local eb6 = EventBus:new()
+    local ps6 = ProfileState:new(bb6, eb6)
+    local ok = ps6:set_profile_state("invalid_state")
+    T.assert_false(ok, "invalid state name should fail")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 7: Set and get operation state
+    -- =====================================================================
+    print("Test 7: Operation state basic")
+    local bb7 = Blackboard:new()
+    local eb7 = EventBus:new()
+    local ps7 = ProfileState:new(bb7, eb7)
+
+    -- Must start as locked
+    local ok = ps7:set_operation_state("op_1", "locked")
+    T.assert_true(ok, "setting initial state 'locked' should succeed")
+    T.assert_equal(ps7:get_operation_state("op_1"), "locked", "op state should be 'locked'")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 8: Valid operation state transitions
+    -- =====================================================================
+    print("Test 8: Valid operation state transitions")
+    local bb8 = Blackboard:new()
+    local eb8 = EventBus:new()
+    local ps8 = ProfileState:new(bb8, eb8)
+
+    ps8:set_operation_state("op_2", "locked")
+    T.assert_true(ps8:set_operation_state("op_2", "ready"), "locked → ready")
+    T.assert_true(ps8:set_operation_state("op_2", "active"), "ready → active")
+    T.assert_true(ps8:set_operation_state("op_2", "completed"), "active → completed")
+
+    -- Test failed path
+    ps8:set_operation_state("op_3", "locked")
+    ps8:set_operation_state("op_3", "ready")
+    ps8:set_operation_state("op_3", "active")
+    T.assert_true(ps8:set_operation_state("op_3", "failed"), "active → failed")
+
+    -- Test aborted path
+    ps8:set_operation_state("op_4", "locked")
+    ps8:set_operation_state("op_4", "ready")
+    ps8:set_operation_state("op_4", "active")
+    T.assert_true(ps8:set_operation_state("op_4", "aborted"), "active → aborted")
+
+    -- Test skipped path
+    ps8:set_operation_state("op_5", "locked")
+    ps8:set_operation_state("op_5", "ready")
+    ps8:set_operation_state("op_5", "active")
+    T.assert_true(ps8:set_operation_state("op_5", "skipped"), "active → skipped")
+
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 9: Invalid operation state transitions
+    -- =====================================================================
+    print("Test 9: Invalid operation state transitions")
+    local bb9 = Blackboard:new()
+    local eb9 = EventBus:new()
+    local ps9 = ProfileState:new(bb9, eb9)
+
+    -- Can't set to ready without first being locked
+    local ok = ps9:set_operation_state("op_6", "ready")
+    T.assert_false(ok, "nil → ready should be invalid (must start as locked)")
+
+    -- Can't skip from locked to active
+    ps9:set_operation_state("op_7", "locked")
+    ok = ps9:set_operation_state("op_7", "active")
+    T.assert_false(ok, "locked → active should be invalid")
+
+    -- Can't go from completed back to ready
+    ps9:set_operation_state("op_8", "locked")
+    ps9:set_operation_state("op_8", "ready")
+    ps9:set_operation_state("op_8", "active")
+    ps9:set_operation_state("op_8", "completed")
+    ok = ps9:set_operation_state("op_8", "ready")
+    T.assert_false(ok, "completed → ready should be invalid")
+
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 10: Invalid operation state name
+    -- =====================================================================
+    print("Test 10: Invalid operation state name")
+    local bb10 = Blackboard:new()
+    local eb10 = EventBus:new()
+    local ps10 = ProfileState:new(bb10, eb10)
+    local ok = ps10:set_operation_state("op_9", "bogus")
+    T.assert_false(ok, "bogus state name should fail")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 11: Operation state with nil/empty op_id
+    -- =====================================================================
+    print("Test 11: Operation state edge cases")
+    local bb11 = Blackboard:new()
+    local eb11 = EventBus:new()
+    local ps11 = ProfileState:new(bb11, eb11)
+
+    local ok = ps11:set_operation_state(nil, "locked")
+    T.assert_false(ok, "nil op_id should fail")
+
+    ok = ps11:set_operation_state("", "locked")
+    T.assert_false(ok, "empty op_id should fail")
+
+    local state = ps11:get_operation_state(nil)
+    T.assert_nil(state, "get with nil op_id should return nil")
+
+    state = ps11:get_operation_state("")
+    T.assert_nil(state, "get with empty op_id should return nil")
+
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 12: Recovery actions
+    -- =====================================================================
+    print("Test 12: Recovery actions")
+    local bb12 = Blackboard:new()
+    local eb12 = EventBus:new()
+    local ps12 = ProfileState:new(bb12, eb12)
+
+    -- Set retry
+    local ok = ps12:set_recovery("op_a", "retry")
+    T.assert_true(ok, "set_recovery retry should succeed")
+    T.assert_equal(ps12:get_recovery("op_a"), "retry", "recovery should be 'retry'")
+
+    -- Set skip
+    ok = ps12:set_recovery("op_a", "skip")
+    T.assert_true(ok, "set_recovery skip should succeed")
+    T.assert_equal(ps12:get_recovery("op_a"), "skip", "recovery should be 'skip'")
+
+    -- Set abort
+    ok = ps12:set_recovery("op_a", "abort")
+    T.assert_true(ok, "set_recovery abort should succeed")
+    T.assert_equal(ps12:get_recovery("op_a"), "abort", "recovery should be 'abort'")
+
+    -- Invalid action
+    ok = ps12:set_recovery("op_a", "invalid")
+    T.assert_false(ok, "invalid recovery action should fail")
+    T.assert_equal(ps12:get_recovery("op_a"), "abort", "recovery should remain 'abort'")
+
+    -- nil/empty op_id
+    ok = ps12:set_recovery(nil, "retry")
+    T.assert_false(ok, "nil op_id should fail")
+    ok = ps12:set_recovery("", "retry")
+    T.assert_false(ok, "empty op_id should fail")
+
+    local rec = ps12:get_recovery(nil)
+    T.assert_nil(rec, "get_recovery with nil op_id should return nil")
+    rec = ps12:get_recovery("")
+    T.assert_nil(rec, "get_recovery with empty op_id should return nil")
+
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 13: Reset clears all state
+    -- =====================================================================
+    print("Test 13: Reset")
+    local bb13 = Blackboard:new()
+    local eb13 = EventBus:new()
+    local ps13 = ProfileState:new(bb13, eb13)
+
+    ps13:set_profile_state("idle")
+    ps13:set_operation_state("op_x", "locked")
+    ps13:set_operation_state("op_y", "locked")
+    ps13:set_recovery("op_x", "retry")
+
+    T.assert_not_nil(ps13:get_profile_state(), "profile state should exist before reset")
+    T.assert_not_nil(ps13:get_operation_state("op_x"), "op_x state should exist before reset")
+
+    ps13:reset()
+
+    T.assert_nil(ps13:get_profile_state(), "profile state should be nil after reset")
+    T.assert_nil(ps13:get_operation_state("op_x"), "op_x state should be nil after reset")
+    T.assert_nil(ps13:get_operation_state("op_y"), "op_y state should be nil after reset")
+    T.assert_nil(ps13:get_recovery("op_x"), "op_x recovery should be nil after reset")
+
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 14: Profile state changed events
+    -- =====================================================================
+    print("Test 14: Profile state events")
+    local bb14 = Blackboard:new()
+    local eb14 = EventBus:new()
+    local ps14 = ProfileState:new(bb14, eb14)
+
+    local profile_events = {}
+    eb14:subscribe("profile_state_changed", function(payload)
+        table.insert(profile_events, payload)
+    end)
+
+    ps14:set_profile_state("idle")
+    ps14:set_profile_state("ready")
+    ps14:set_profile_state("executing")
+
+    T.assert_equal(#profile_events, 3, "should have 3 profile state events")
+    T.assert_nil(profile_events[1].from, "first event from should be nil")
+    T.assert_equal(profile_events[1].to, "idle", "first event to should be 'idle'")
+    T.assert_equal(profile_events[2].from, "idle", "second event from should be 'idle'")
+    T.assert_equal(profile_events[2].to, "ready", "second event to should be 'ready'")
+    T.assert_equal(profile_events[3].from, "ready", "third event from should be 'ready'")
+    T.assert_equal(profile_events[3].to, "executing", "third event to should be 'executing'")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 15: Operation state changed events
+    -- =====================================================================
+    print("Test 15: Operation state events")
+    local bb15 = Blackboard:new()
+    local eb15 = EventBus:new()
+    local ps15 = ProfileState:new(bb15, eb15)
+
+    local op_events = {}
+    eb15:subscribe("operation_state_changed", function(payload)
+        table.insert(op_events, payload)
+    end)
+
+    ps15:set_operation_state("op_z", "locked")
+    ps15:set_operation_state("op_z", "ready")
+    ps15:set_operation_state("op_z", "active")
+    ps15:set_operation_state("op_z", "completed")
+
+    T.assert_equal(#op_events, 4, "should have 4 operation state events")
+    T.assert_equal(op_events[1].operation_id, "op_z")
+    T.assert_nil(op_events[1].from, "first op event from should be nil")
+    T.assert_equal(op_events[1].to, "locked", "first op event to should be 'locked'")
+    T.assert_equal(op_events[2].from, "locked")
+    T.assert_equal(op_events[2].to, "ready")
+    T.assert_equal(op_events[3].from, "ready")
+    T.assert_equal(op_events[3].to, "active")
+    T.assert_equal(op_events[4].from, "active")
+    T.assert_equal(op_events[4].to, "completed")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 16: Setting same state is idempotent (no event published)
+    -- =====================================================================
+    print("Test 16: Idempotent state setting")
+    local bb16 = Blackboard:new()
+    local eb16 = EventBus:new()
+    local ps16 = ProfileState:new(bb16, eb16)
+
+    local count = 0
+    eb16:subscribe("profile_state_changed", function() count = count + 1 end)
+    eb16:subscribe("operation_state_changed", function() count = count + 1 end)
+
+    ps16:set_profile_state("idle")
+    T.assert_equal(count, 1, "1 event so far")
+
+    -- Set same state again — no event should be published but returns true
+    local ok = ps16:set_profile_state("idle")
+    T.assert_true(ok, "setting same state should return true")
+    T.assert_equal(count, 1, "no additional event for same state")
+
+    ps16:set_operation_state("op_z", "locked")
+    T.assert_equal(count, 2, "2 events so far")
+
+    ok = ps16:set_operation_state("op_z", "locked")
+    T.assert_true(ok, "setting same op state should return true")
+    T.assert_equal(count, 2, "no additional event for same op state")
+
+    print("  PASS")
+
+    print("\n=== All ProfileState Tests PASSED ===")
+end
+
+return M

--- a/sentinel/tests/runtime/test_variable_store.lua
+++ b/sentinel/tests/runtime/test_variable_store.lua
@@ -1,0 +1,235 @@
+-- sentinel/tests/runtime/test_variable_store.lua
+-- Tests for runtime/variable_store.lua
+
+local Blackboard = require("core/blackboard")
+local T = require("tests/test_util")
+
+local M = {}
+
+function M.run()
+    print("=== Variable Store Tests ===")
+
+    -- =====================================================================
+    -- Test 1: Construction
+    -- =====================================================================
+    print("Test 1: Construction")
+    local bb = Blackboard:new()
+    local VariableStore = require("runtime/variable_store")
+    local vs = VariableStore:new(bb)
+    T.assert_not_nil(vs, "VariableStore instance should not be nil")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 2: Set and get a boolean value
+    -- =====================================================================
+    print("Test 2: Set and get boolean")
+    local bb2 = Blackboard:new()
+    local vs2 = VariableStore:new(bb2)
+    local ok, err = vs2:set("global", "is_ready", true)
+    T.assert_true(ok, "set global boolean should succeed")
+    T.assert_nil(err, "error should be nil")
+    local val = vs2:get("global", "is_ready")
+    T.assert_equal(val, true, "should retrieve true")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 3: Set and get integer value
+    -- =====================================================================
+    print("Test 3: Set and get integer")
+    local bb3 = Blackboard:new()
+    local vs3 = VariableStore:new(bb3)
+    vs3:set("global", "count", 42)
+    local val = vs3:get("global", "count")
+    T.assert_equal(val, 42, "should retrieve integer 42")
+    T.assert_equal(type(val), "number", "should be a number")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 4: Set and get float value
+    -- =====================================================================
+    print("Test 4: Set and get float")
+    local bb4 = Blackboard:new()
+    local vs4 = VariableStore:new(bb4)
+    vs4:set("global", "distance", 3.14)
+    local val = vs4:get("global", "distance")
+    T.assert_equal(val, 3.14, "should retrieve 3.14")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 5: Set and get string value
+    -- =====================================================================
+    print("Test 5: Set and get string")
+    local bb5 = Blackboard:new()
+    local vs5 = VariableStore:new(bb5)
+    vs5:set("global", "name", "TestChar")
+    local val = vs5:get("global", "name")
+    T.assert_equal(val, "TestChar", "should retrieve string")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 6: Set and get position value
+    -- =====================================================================
+    print("Test 6: Set and get position")
+    local bb6 = Blackboard:new()
+    local vs6 = VariableStore:new(bb6)
+    local pos = { x = 100.5, y = 200.3, z = 30.0, zone = "Elwynn" }
+    local ok, err = vs6:set("global", "home", pos)
+    T.assert_true(ok, "set position should succeed")
+    T.assert_nil(err, "error should be nil")
+    local val = vs6:get("global", "home")
+    T.assert_equal(val.x, 100.5, "x coordinate should match")
+    T.assert_equal(val.y, 200.3, "y coordinate should match")
+    T.assert_equal(val.zone, "Elwynn", "zone should match")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 7: Invalid type (table without x/y/zone) should be rejected
+    -- =====================================================================
+    print("Test 7: Invalid type rejection")
+    local bb7 = Blackboard:new()
+    local vs7 = VariableStore:new(bb7)
+    local ok, err = vs7:set("global", "bad", { a = 1, b = 2 })
+    T.assert_false(ok, "set invalid table should fail")
+    T.assert_not_nil(err, "should return an error")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 8: Global fallthrough when scope is not "global"
+    -- =====================================================================
+    print("Test 8: Global fallthrough")
+    local bb8 = Blackboard:new()
+    local vs8 = VariableStore:new(bb8)
+    vs8:set("global", "theme", "dark")
+    -- Read from operation scope without setting it there
+    local val = vs8:get("operation_1", "theme")
+    T.assert_equal(val, "dark", "should fall through to global scope")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 9: Operation scope overrides global
+    -- =====================================================================
+    print("Test 9: Operation scope overrides global")
+    local bb9 = Blackboard:new()
+    local vs9 = VariableStore:new(bb9)
+    vs9:set("global", "speed", "normal")
+    vs9:set("op_123", "speed", "fast")
+    local global_val = vs9:get("global", "speed")
+    local op_val = vs9:get("op_123", "speed")
+    T.assert_equal(global_val, "normal", "global should be 'normal'")
+    T.assert_equal(op_val, "fast", "operation scope should override with 'fast'")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 10: Has, Delete, and List
+    -- =====================================================================
+    print("Test 10: Has, Delete, and List")
+    local bb10 = Blackboard:new()
+    local vs10 = VariableStore:new(bb10)
+    vs10:set("global", "alpha", 1)
+    vs10:set("global", "beta", 2)
+    vs10:set("op_x", "gamma", 3)
+
+    -- Has
+    T.assert_true(vs10:has("global", "alpha"), "should have alpha")
+    T.assert_false(vs10:has("global", "nonexistent"), "should not have nonexistent")
+
+    -- List
+    local global_keys = vs10:list("global")
+    T.assert_equal(#global_keys, 2, "should have 2 global keys")
+    T.assert_equal(global_keys[1], "alpha", "sorted: alpha first")
+    T.assert_equal(global_keys[2], "beta", "sorted: beta second")
+
+    local op_keys = vs10:list("op_x")
+    T.assert_equal(#op_keys, 1, "should have 1 op_x key")
+    T.assert_equal(op_keys[1], "gamma", "op_x key should be gamma")
+
+    -- Delete
+    local deleted = vs10:delete("global", "alpha")
+    T.assert_true(deleted, "delete should return true")
+    T.assert_false(vs10:has("global", "alpha"), "alpha should be gone")
+    T.assert_equal(#vs10:list("global"), 1, "only beta should remain")
+
+    -- Delete nonexistent
+    local deleted2 = vs10:delete("global", "nonexistent")
+    T.assert_false(deleted2, "delete nonexistent should return false")
+
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 11: Clear scope
+    -- =====================================================================
+    print("Test 11: Clear scope")
+    local bb11 = Blackboard:new()
+    local vs11 = VariableStore:new(bb11)
+    vs11:set("global", "a", 1)
+    vs11:set("global", "b", 2)
+    vs11:set("op_y", "c", 3)
+
+    vs11:clear_scope("global")
+    T.assert_equal(#vs11:list("global"), 0, "global scope should be empty")
+    T.assert_equal(#vs11:list("op_y"), 1, "op_y scope should be untouched")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 12: Get type
+    -- =====================================================================
+    print("Test 12: Get type")
+    local bb12 = Blackboard:new()
+    local vs12 = VariableStore:new(bb12)
+    vs12:set("global", "flag", false)
+    vs12:set("global", "age", 25)
+    vs12:set("global", "ratio", 1.5)
+    vs12:set("global", "msg", "hello")
+    vs12:set("global", "loc", { x = 0, y = 0, z = 0, zone = "Test" })
+
+    T.assert_equal(vs12:get_type("global", "flag"), "bool", "flag should be bool")
+    T.assert_equal(vs12:get_type("global", "age"), "integer", "age should be integer")
+    T.assert_equal(vs12:get_type("global", "ratio"), "float", "ratio should be float")
+    T.assert_equal(vs12:get_type("global", "msg"), "string", "msg should be string")
+    T.assert_equal(vs12:get_type("global", "loc"), "position", "loc should be position")
+
+    -- Nonexistent
+    T.assert_nil(vs12:get_type("global", "void"), "void should be nil")
+    print("  PASS")
+
+    -- =====================================================================
+    -- Test 13: Scope/key validation edge cases
+    -- =====================================================================
+    print("Test 13: Edge cases")
+    local bb13 = Blackboard:new()
+    local vs13 = VariableStore:new(bb13)
+
+    -- Empty scope
+    local ok, err = vs13:set("", "key", "val")
+    T.assert_false(ok, "empty scope should fail")
+
+    -- Empty key
+    ok, err = vs13:set("global", "", "val")
+    T.assert_false(ok, "empty key should fail")
+
+    -- Nil scope
+    local val = vs13:get(nil, "key")
+    T.assert_nil(val, "nil scope should return nil")
+
+    -- Nil key
+    val = vs13:get("global", nil)
+    T.assert_nil(val, "nil key should return nil")
+
+    -- has with invalid params
+    T.assert_false(vs13:has("", "key"), "empty scope has should be false")
+    T.assert_false(vs13:has("global", ""), "empty key has should be false")
+
+    -- list with invalid scope
+    local keys = vs13:list("")
+    T.assert_equal(#keys, 0, "empty scope list should be empty")
+
+    -- clear_scope with invalid scope
+    local cleared = vs13:clear_scope("")
+    T.assert_false(cleared, "empty scope clear should be false")
+
+    print("  PASS")
+
+    print("\n=== All VariableStore Tests PASSED ===")
+end
+
+return M


### PR DESCRIPTION
Closes #13

## Changes

Three supporting subsystems for the runtime engine (#12):

### Variable Store (`sentinel/runtime/variable_store.lua`)
- Typed key-value store with blackboard-backed persistence
- Type inference: bool, integer, float, string, position (table with x/y/zone)
- Global fallthrough: operation-scoped reads fall back to global scope
- Full CRUD: set, get, has, delete, list, clear_scope, get_type
- Storage at `module.runtime.variables.{scope}.{key}`

### Event Dispatcher (`sentinel/runtime/event_dispatcher.lua`)
- Maps Sylvannas game events to runtime events with structured payloads
- Graceful handling of missing Sylvannas events via pcall
- Subscription management for runtime event handlers
- Event mapping: QUEST_LOG_UPDATE, UNIT_HEALTH, BAG_UPDATE, PLAYER_ENTERING_WORLD, PLAYER_DEATH, UNIT_COMBAT

### Profile State (`sentinel/runtime/profile_state.lua`)
- Profile state machine: idle → ready → executing → waiting → finished (back to idle)
- Operation state machine: locked → ready → active → completed|failed|aborted|skipped
- Validated transitions with event publishing
- Recovery action management (retry/skip/abort)
- Full reset capability

## Testing

- `test_variable_store.lua`: 13 tests covering CRUD, type inference, global fallthrough, scope isolation, edge cases
- `test_event_dispatcher.lua`: 10 tests covering subscribe/unsubscribe, payload delivery, multiple subscribers, Sylvannas integration
- `test_profile_state.lua`: 16 tests covering valid/invalid transitions, events, recovery, reset, idempotency
- All tests run via `luajit sentinel/tests/run_offline.lua`